### PR TITLE
Changing up names

### DIFF
--- a/src/Command/Command/TradeRepeater/Monitor.php
+++ b/src/Command/Command/TradeRepeater/Monitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kobens\Exchange\Command\Command\SimpleTrader;
+namespace Kobens\Exchange\Command\Command\TradeRepeater;
 
 use Kobens\Core\Command\Traits\Traits;
 use Kobens\Core\Config;
@@ -8,8 +8,8 @@ use Kobens\Core\Exception\ConnectionException;
 use Kobens\Exchange\Exception\LogicException;
 use Kobens\Exchange\ExchangeInterface;
 use Kobens\Exchange\Exchange\Mapper;
-use Kobens\Exchange\Trader\SimpleRepeater;
-use Kobens\Exchange\Trader\SimpleRepeater\OrderId;
+use Kobens\Exchange\TradeStrategies\Repeater;
+use Kobens\Exchange\TradeStrategies\Repeater\OrderId;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +26,7 @@ final class Monitor extends Command
     private $log;
 
     /**
-     * @var SimpleRepeater
+     * @var Repeater
      */
     private $repeater;
 
@@ -37,8 +37,8 @@ final class Monitor extends Command
 
     protected function configure()
     {
-        $this->setName('exchange:trader:simple-repeater:monitor');
-        $this->setDescription('Monitors the status of placed orders for the simple trade repeater');
+        $this->setName('kobens:exchange:trade-repeater:monitor');
+        $this->setDescription('Monitors the status of placed orders for the trade repeater');
     }
 
     /**
@@ -48,7 +48,7 @@ final class Monitor extends Command
      */
     protected function initialize($input, $output): void
     {
-        $this->repeater = new SimpleRepeater();
+        $this->repeater = new Repeater();
         $this->mapper   = new Mapper();
         $this->log      = new Logger('simple_trade_monitor');
         $this->log->pushHandler(new StreamHandler(
@@ -136,7 +136,7 @@ final class Monitor extends Command
         $status = $exchange->getStatusInterface();
         $meta = $exchange->getOrderMetaData($order->exchangeOrderId);
         switch (true) {
-            case $status->isFilled($meta) && $order->status === SimpleRepeater::STATUS_BUY_PLACED:
+            case $status->isFilled($meta) && $order->status === Repeater::STATUS_BUY_PLACED:
                 $this->repeater->markBuyFilled($order->orderId, $order->exchange);
                 $output->write(PHP_EOL);
                 $output->write(\sprintf(
@@ -146,7 +146,7 @@ final class Monitor extends Command
                     ucwords($order->exchange)
                 ));
                 break;
-            case $status->isFilled($meta) && $order->status === SimpleRepeater::STATUS_SELL_PLACED:
+            case $status->isFilled($meta) && $order->status === Repeater::STATUS_SELL_PLACED:
                 $this->repeater->markSellFilled($order->orderId, $order->exchange);
                 $output->write(PHP_EOL);
                 $output->write(\sprintf(

--- a/src/Command/Command/TradeRepeater/OrderPlacer.php
+++ b/src/Command/Command/TradeRepeater/OrderPlacer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kobens\Exchange\Command\Command\SimpleTrader;
+namespace Kobens\Exchange\Command\Command\TradeRepeater;
 
 use Kobens\Core\Command\Traits\Traits;
 use Kobens\Core\Config;
@@ -8,8 +8,8 @@ use Kobens\Core\Exception\ConnectionException;
 use Kobens\Exchange\Exception\Order\MakerOrCancelWouldTakeException;
 use Kobens\Exchange\Exception\LogicException;
 use Kobens\Exchange\Exchange\Mapper;
-use Kobens\Exchange\Trader\SimpleRepeater;
-use Kobens\Exchange\Trader\SimpleRepeater\NewOrderInterface;
+use Kobens\Exchange\TradeStrategies\Repeater;
+use Kobens\Exchange\TradeStrategies\Repeater\NewOrderInterface;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +26,7 @@ final class OrderPlacer extends Command
     private $log = [];
 
     /**
-     * @var SimpleRepeater
+     * @var Repeater
      */
     private $repeater;
 
@@ -37,13 +37,13 @@ final class OrderPlacer extends Command
 
     protected function configure()
     {
-        $this->setName('exchange:trader:simple-repeater:order-placer');
-        $this->setDescription('Places buy and sell orders for the simple trade repeater.');
+        $this->setName('kobens:exchange:trade-repeater:place');
+        $this->setDescription('Places buy and sell orders for the trade repeater.');
     }
 
     protected function initialize($input, $output)
     {
-        $this->repeater = new SimpleRepeater();
+        $this->repeater = new Repeater();
         $this->mapper = new Mapper();
         $this->log['main'] = new Logger('simple_trade_repeater');
         $this->log['main']->pushHandler(new StreamHandler(

--- a/src/TradeStrategies/Repeater.php
+++ b/src/TradeStrategies/Repeater.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Kobens\Exchange\Trader;
+namespace Kobens\Exchange\TradeStrategies;
 
 use Kobens\Core\Db;
-use Kobens\Exchange\Trader\SimpleRepeater\{NewOrder, OrderId};
+use Kobens\Exchange\TradeStrategies\Repeater\{NewOrder, OrderId};
 use Zend\Db\Sql\Select;
 use Zend\Db\TableGateway\TableGateway;
 use Zend\Db\ResultSet\ResultSetInterface;
 
-final class SimpleRepeater
+final class Repeater
 {
     const TABLE_NAME = 'trader_simple_repeater';
 

--- a/src/TradeStrategies/Repeater/NewOrder.php
+++ b/src/TradeStrategies/Repeater/NewOrder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kobens\Exchange\Trader\SimpleRepeater;
+namespace Kobens\Exchange\TradeStrategies\Repeater;
 
 use Kobens\Exchange\Exception\InvalidArgumentException;
 

--- a/src/TradeStrategies/Repeater/NewOrderInterface.php
+++ b/src/TradeStrategies/Repeater/NewOrderInterface.php
@@ -1,5 +1,6 @@
 <?php
-namespace Kobens\Exchange\Trader\SimpleRepeater;
+
+namespace Kobens\Exchange\TradeStrategies\Repeater;
 
 /**
  * @property-read int $id

--- a/src/TradeStrategies/Repeater/OrderId.php
+++ b/src/TradeStrategies/Repeater/OrderId.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kobens\Exchange\Trader\SimpleRepeater;
+namespace Kobens\Exchange\TradeStrategies\Repeater;
 
 use Kobens\Exchange\Exception\InvalidArgumentException;
 

--- a/src/TradeStrategies/Repeater/PositionGenerator.php
+++ b/src/TradeStrategies/Repeater/PositionGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kobens\Exchange\Trader\SimpleRepeater;
+namespace Kobens\Exchange\TradeStrategies\Repeater;
 
 use Kobens\Exchange\Exchange\Mapper;
 use Kobens\Exchange\PairInterface;
@@ -24,12 +24,8 @@ final class PositionGenerator
 
     public function __construct($exchangeKey, $pairKey)
     {
-        $mapper = new Mapper();
-        $exchange = $mapper->getExchange($exchangeKey);
-        $this->pair = $exchange->getPair($pairKey);
-
-
-        $this->mapper = $mapper;
+        $this->mapper = new Mapper();
+        $this->pair = $this->mapper->getExchange($exchangeKey)->getPair($pairKey);
     }
 
     public function generate(


### PR DESCRIPTION
- Prefixed commands with `vendor-name:vendor-package` format
- Re-assessed name to the trade repeater. Nuked "simple" out of it which was sometimes present sometimes not in descriptions/names. It's the trade repeater strategy.